### PR TITLE
更新 `SettingsPageView.xaml` 中按钮绑定，增加“返回”按钮功能

### DIFF
--- a/Helldivers2ModManager/Components/MessageBox.xaml
+++ b/Helldivers2ModManager/Components/MessageBox.xaml
@@ -39,16 +39,14 @@
 					<RowDefinition Height="*"/>
 					<RowDefinition Height="Auto"/>
 				</Grid.RowDefinitions>
-				<ScrollViewer Grid.Row="0"
-							  Margin="3"
-							  Padding="3"
-							  VerticalScrollBarVisibility="Auto"
-							  HorizontalScrollBarVisibility="Auto">
-					<TextBlock x:Name="message"
-							   Foreground="WhiteSmoke"
-							   FontSize="16"
-							   FontFamily="Sanserif"/>
-				</ScrollViewer>
+				<TextBlock Grid.Row="0"
+						   x:Name="message"
+						   Foreground="WhiteSmoke"
+						   FontSize="16"
+						   FontFamily="Sanserif"
+						   TextWrapping="Wrap"
+						   Margin="10"
+						   Padding="3"/>
 				<TextBox Grid.Row="1"
 						 x:Name="input"
 						 Margin="3"/>
@@ -65,14 +63,23 @@
 					Click="OkButton_Click"/>
 			<Grid Grid.Row="2"
 				  x:Name="yesNoStack">
-				<Button x:Name="yesButton"
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*"/>
+					<ColumnDefinition Width="Auto"/>
+					<ColumnDefinition Width="Auto"/>
+				</Grid.ColumnDefinitions>
+				<Button Grid.Column="1"
+						x:Name="yesButton"
 						Content="Yes"
 						Click="YesButton_Click"
-						HorizontalAlignment="Left"/>
-				<Button x:Name="noButton"
+						HorizontalAlignment="Right"
+						Margin="3,3,0,3"/>
+				<Button Grid.Column="2"
+						x:Name="noButton"
 						Content="No"
 						Click="NoButton_Click"
-						HorizontalAlignment="Right"/>
+						HorizontalAlignment="Right"
+						Margin="3"/>
 			</Grid>
 			<ProgressBar Grid.Row="2"
 						 x:Name="progress"

--- a/Helldivers2ModManager/Models/ModSubOption.cs
+++ b/Helldivers2ModManager/Models/ModSubOption.cs
@@ -22,7 +22,7 @@ internal sealed class ModSubOption : IJsonSerializable<ModSubOption>
         if (!root.TryGetProperty(nameof(Include), out var prop))
 			throw new SerializationException($"Could not find property of name \"{nameof(Include)}\"!");
 		if (prop.ValueKind != JsonValueKind.Array)
-			throw new SerializationException($"Property \"{nameof(Include)}\" was not of expected type ´array´!");
+			throw new SerializationException($"Property \"{nameof(Include)}\" was not of expected type array?");
 		var include = new List<string>(prop.GetArrayLength());
         foreach (var elm in prop.EnumerateArray())
             if (elm.ValueKind == JsonValueKind.String)

--- a/Helldivers2ModManager/Services/LocalizationService.cs
+++ b/Helldivers2ModManager/Services/LocalizationService.cs
@@ -41,7 +41,7 @@ internal sealed class LocalizationService : INotifyPropertyChanged
 		}
 	}
 
-	private static readonly DirectoryInfo s_languageDir = new("Languages");
+	private static readonly DirectoryInfo s_languageDir = new("languages");
 	private readonly ILogger<LocalizationService> _logger;
 	private readonly Dictionary<string, string> _translations = new();
 	private string _currentLanguage = "en";
@@ -177,7 +177,10 @@ internal sealed class LocalizationService : INotifyPropertyChanged
 			["Settings.DevOptions"] = "Dev Options",
 			["Settings.SkipList"] = "Skip List",
 			["Settings.SkipListDesc"] = "This skips the 0th index of all specified files during deployment.",
+			["Settings.Back"] = "Back",
 			["Settings.OK"] = "OK",
+			["Settings.DiscardChangesTitle"] = "Discard Changes?",
+			["Settings.DiscardChangesMessage"] = "You have unsaved changes. Do you want to discard them and return to the main screen?",
 			["Settings.Language"] = "Language",
 			["Settings.LanguageDesc"] = "Select your preferred language for the interface.",
 			
@@ -293,7 +296,10 @@ internal sealed class LocalizationService : INotifyPropertyChanged
 			["Settings.DevOptions"] = "开发者选项",
 			["Settings.SkipList"] = "跳过列表",
 			["Settings.SkipListDesc"] = "在部署期间跳过所有指定文件的第0个索引。",
+			["Settings.Back"] = "返回",
 			["Settings.OK"] = "确定",
+			["Settings.DiscardChangesTitle"] = "放弃更改？",
+			["Settings.DiscardChangesMessage"] = "您有未保存的更改。是否要放弃这些更改并返回主界面？",
 			["Settings.Language"] = "语言",
 			["Settings.LanguageDesc"] = "选择您喜欢的界面语言。",
 			

--- a/Helldivers2ModManager/Views/SettingsPageView.xaml
+++ b/Helldivers2ModManager/Views/SettingsPageView.xaml
@@ -250,9 +250,22 @@
 			</StackPanel>
 		</ScrollViewer>
 		<Grid Grid.Row="1">
-			<Button Content="{Binding OKLabel}"
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*"/>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="Auto"/>
+			</Grid.ColumnDefinitions>
+			<Button Grid.Column="1"
+					Content="{Binding BackLabel}"
+					Command="{Binding BackCommand}"
+					Style="{DynamicResource CancelButton}"
+					HorizontalAlignment="Right"
+					Margin="3"/>
+			<Button Grid.Column="2"
+					Content="{Binding OKLabel}"
 					Command="{Binding OkCommand}"
-					HorizontalAlignment="Right"/>
+					HorizontalAlignment="Right"
+					Margin="3"/>
 		</Grid>
 	</Grid>
 </Page>

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 A simple mod manager for the game Helldivers 2.
 
-Read more about it on the [website](https://teutinsa.github.io/hd2mm-site/index.html).
+一个简单的 Helldivers 2 游戏模组管理器。
+
+Read more about it on the [website](https://www.iryougi.com/index.php/hd2help/).


### PR DESCRIPTION
在 `MessageBox.xaml` 中移除 `ScrollViewer`，替换为可自动换行的 `TextBlock`，并调整按钮布局。 在 `ModSubOption.cs` 中改善错误信息描述。
在 `LocalizationService.cs` 中修改语言目录名称并添加新本地化字符串。
在 `SettingsPageViewModel.cs` 中实现初始状态跟踪和更改检测功能。
更新 `README.md` 和 `设置界面返回按钮功能说明.md`，提供新功能的详细说明。